### PR TITLE
Changed `func` to `f` in the min versions

### DIFF
--- a/hexmaniac.min.lua
+++ b/hexmaniac.min.lua
@@ -23,4 +23,4 @@ function f.rgbo(s, opacity)
         opacity
     }
 end
-return func
+return f

--- a/hexmaniacold.min.lua
+++ b/hexmaniacold.min.lua
@@ -23,4 +23,4 @@ function f.rgbo(s, opacity)
         opacity*255
     }
 end
-return func
+return f


### PR DESCRIPTION
In the minified versions, you were still having the files return `func` when you had renamed it to `f`. Pretty sure that causes issues.

Might want to squash this request if you accept it because I did it through the github website so there is two commits where it would only need one.